### PR TITLE
Implement a typed "any" object

### DIFF
--- a/include/mpt/all.hpp
+++ b/include/mpt/all.hpp
@@ -3,6 +3,7 @@
 #include "mpt/members.hpp"
 #include "mpt/signature.hpp"
 #include "mpt/smart_enum.hpp"
+#include "mpt/typed_any.hpp"
 #include "mpt/types.hpp"
 #include "mpt/values.hpp"
 

--- a/include/mpt/typed_any.hpp
+++ b/include/mpt/typed_any.hpp
@@ -1,0 +1,204 @@
+#pragma once
+#include "mpt/types.hpp"
+#include <any>
+#include <array>
+#include <functional>
+
+namespace mpt {
+
+  namespace detail {
+    /// Find the first class in the template argument list that is
+    /// default-constructible
+    template <class... T> struct first_object_default_constructible;
+
+#ifndef MPT_DOXYGEN_WARD
+    template <class T>
+    concept IsDefaultConstructible = std::is_default_constructible_v<T>;
+
+    template <class T0, class... T>
+    requires IsDefaultConstructible<
+        T0> struct first_object_default_constructible<T0, T...> {
+      using type = T0;
+    };
+
+    template <class T0, class... T>
+    requires(!IsDefaultConstructible<
+             T0>) struct first_object_default_constructible<T0, T...> {
+      using type = typename first_object_default_constructible<T...>::type;
+    };
+#endif
+
+    /// First class in the template argument list that is default-constructible
+    template <class... T>
+    using first_object_default_constructible_t =
+        typename first_object_default_constructible<T...>::type;
+  } // namespace detail
+
+  /*\brief Represent an object that can hold any of a set of types, saving the
+    index of the type
+
+    The behaviour is quite similar to std::variant, but in this case the size of
+    the object is not determined by the size of the biggest object from the
+    template argument list. The value is stored on a std::any object and the
+    type index is saved as an integer. The actual value can be accessed using
+    mpt::visit_typed_any (similarly to std::variant).
+
+    This class is meant to be used when it is needed to have an object that
+    might be any of a set of types that have very different size in memory.
+
+    It is not recommended to use this class on lightweight classes stored in
+    large containers due to the cost of having an additional integer saving the
+    type of each of them. If all of them are of the same type, it is probably
+    better to use std::variant since all the containers store a pointer and an
+    integer (i.e. are of the same size in memory).
+   */
+  template <class... Type>
+  requires mpt::UniqueTemplateArguments<Type...>
+      &&mpt::NonEmptyTemplateArguments<Type...> class typed_any {
+
+    /// Object to build if using the default constructor
+    using default_value_type =
+        detail::first_object_default_constructible_t<Type...>;
+
+  public:
+    // Default constructors and assignment operators
+    typed_any() = default;
+    typed_any(typed_any const &) = default;
+    typed_any(typed_any &&) = default;
+    typed_any &operator=(typed_any const &) = default;
+    typed_any &operator=(typed_any &&) = default;
+
+    /// Initialize the object from a value type, which must be in the template
+    /// argument list
+    template <class T>
+    requires mpt::HasType<T, Type...> constexpr typed_any(T const &t)
+        : m_value{t}, m_type_index{mpt::type_index_v<T, Type...>} {}
+    /// Initialize the object from a value type, which must be in the template
+    /// argument list
+    template <class T>
+    requires mpt::HasType<T, Type...> constexpr typed_any(T &&t)
+        : m_value{std::forward<T>(t)}, m_type_index{
+                                           mpt::type_index_v<T, Type...>} {}
+    /// Assign the contained value another value that must be in the template
+    /// argument list
+    template <class T>
+    requires mpt::HasType<T, Type...> constexpr typed_any &
+    operator=(T const &t) {
+      m_value = t;
+      m_type_index = mpt::type_index_v<T, Type...>;
+      return *this;
+    }
+    /// Assign the contained value another value that must be in the template
+    /// argument list
+    template <class T>
+    requires mpt::HasType<T, Type...> constexpr typed_any &operator=(T &&t) {
+      m_value = std::forward<T>(t);
+      m_type_index = mpt::type_index_v<T, Type...>;
+      return *this;
+    }
+
+    /// Return the contained std::any object
+    constexpr auto &value() { return m_value; }
+    /// Return the contained std::any object
+    constexpr auto const &value() const { return m_value; }
+    /// Return the index of the contained type
+    constexpr auto type_index() const { return m_type_index; }
+
+  protected:
+    /// Any object this class accepts
+    std::any m_value = default_value_type{};
+    /// Index of the current type
+    std::size_t m_type_index = mpt::type_index_v<default_value_type, Type...>;
+  };
+
+  namespace detail {
+
+    /// Access a value on a std::any object
+    template <class Function, class T>
+    auto access(Function &&function, std::any &a) {
+      return function(std::any_cast<T>(a));
+    }
+
+    /// Access a value on a std::any object
+    template <class Function, class T>
+    auto access(Function &&function, std::any const &a) {
+      return function(std::any_cast<T const>(a));
+    }
+
+    /// Access a value on a std::any object
+    template <class Function, class T>
+    auto access(Function &&function, std::any &&a) {
+      return function(std::any_cast<T>(std::move(a)));
+    }
+
+    /// Requirements for any accessor to a mpt::typed_any object
+    template <class Function, class... T>
+    concept Accessor = (mpt::NonEmptyTemplateArguments<T...> &&
+                        mpt::are_same_v<decltype(std::invoke(
+                            std::declval<Function>(), std::declval<T>()))...>);
+
+    /// Define an array of functions that are called for each type handled by
+    /// mpt::typed_any
+    template <class TypedAny, class Function> struct accessors;
+
+    /// Specialization for reference
+    template <class Function, class... T>
+    requires Accessor<Function, T...> struct accessors<typed_any<T...> &,
+                                                       Function> {
+
+      using output_type = decltype(std::invoke(
+          std::declval<Function>(), std::declval<mpt::type_at_t<0, T...>>()));
+
+      static constexpr std::array<output_type (*)(Function &&, std::any &),
+                                  sizeof...(T)>
+          value = {&access<Function, T>...};
+    };
+
+    /// Specialization for constant reference
+    template <class Function, class... T>
+    requires Accessor<Function, T...> struct accessors<typed_any<T...> const &,
+                                                       Function> {
+
+      using output_type = decltype(
+          std::invoke(std::declval<Function>(),
+                      std::declval<mpt::type_at_t<0, T...> const &>()));
+
+      static constexpr std::array<
+          output_type (*)(Function &&, std::any const &), sizeof...(T)>
+          value = {&access<Function, T const>...};
+    };
+
+    /// Specialization for move operations
+    template <class Function, class... T>
+    requires Accessor<Function, T...> struct accessors<typed_any<T...> &&,
+                                                       Function> {
+
+      using output_type = decltype(std::invoke(
+          std::declval<Function>(), std::declval<mpt::type_at_t<0, T...>>()));
+
+      static constexpr std::array<output_type (*)(Function &&, std::any &&),
+                                  sizeof...(T)>
+          value = {&access<Function, T>...};
+    };
+  } // namespace detail
+
+  /// Apply a function on the given typed "any" object
+  template <class Function, class TypedAny>
+  auto visit_typed_any(Function &&function, TypedAny &&any) {
+
+    static constexpr auto is_rvalue_reference =
+        std::is_rvalue_reference_v<decltype(any)>;
+
+    static constexpr auto accessors =
+        std::conditional_t<is_rvalue_reference,
+                           detail::accessors<TypedAny &&, Function>,
+                           detail::accessors<TypedAny, Function>>::value;
+
+    if constexpr (is_rvalue_reference)
+      return accessors[any.type_index()](std::forward<Function>(function),
+                                         std::move(any.value()));
+    else
+      return accessors[any.type_index()](std::forward<Function>(function),
+                                         any.value());
+  }
+} // namespace mpt

--- a/include/mpt/types.hpp
+++ b/include/mpt/types.hpp
@@ -33,6 +33,10 @@ namespace mpt {
   };
 #endif
 
+  /// Restriction to specializations where the given type is in the template
+  /// argument list
+  template <class R, class... T> concept HasType = has_type_v<R, T...>;
+
   /// Whether the type is in the given template type
   template <class Reference, class Object>
   static constexpr auto templated_object_has_type_v =
@@ -53,6 +57,11 @@ namespace mpt {
   template <class... T>
   static constexpr auto has_repeated_template_arguments_v =
       has_repeated_template_arguments<T...>::value;
+
+  /// Restriction to specializations where the given type is in the template
+  /// argument list
+  template <class... T>
+  concept UniqueTemplateArguments = !has_repeated_template_arguments_v<T...>;
 
   /// Whether the type is in the given template type
   template <class Reference, class Object>
@@ -137,6 +146,16 @@ namespace mpt {
   template <std::size_t I, class Object>
   using templated_object_type_at_t =
       typename templated_object_type_at<I, Object>::type;
+
+  /// Number of template arguments
+  template <class... T> struct template_object_elements {
+    static constexpr auto value = sizeof...(T);
+  };
+
+  /// Number of template arguments
+  template <class... T>
+  static constexpr auto template_object_elements_v =
+      template_object_elements<T...>::value;
 
   namespace {
 
@@ -229,5 +248,38 @@ namespace mpt {
   template <template <class...> class Template, class... T>
   using specialize_template_avoid_repetitions_t =
       typename specialize_template_avoid_repetitions<Template, T...>::type;
+
+  /// Restriction for templates that must have at least one argument
+  template <class... T> concept NonEmptyTemplateArguments = (sizeof...(T) > 0);
+
+  /// Check if two template arguments are the same (equivalent to std::is_same)
+  template <class U, class V> struct is_same;
+
+#ifndef MPT_DOXYGEN_WARD
+  template <class U, class V> struct is_same : std::false_type {};
+
+  template <class U> struct is_same<U, U> : std::true_type {};
+#endif
+
+  /// Check if two template arguments are the same (equivalent to std::is_same)
+  template <class U, class V>
+  static constexpr auto is_same_v = is_same<U, V>::value;
+
+  /// Check if all the template arguments are the same
+  template <class... T> struct are_same;
+
+#ifndef MPT_DOXYGEN_WARD
+  template <class T0, class T1, class... T>
+  struct are_same<T0, T1, T...> : std::false_type {};
+
+  template <class T0, class... T>
+  struct are_same<T0, T0, T...> : are_same<T0, T...> {};
+
+  template <class T> struct are_same<T> : std::true_type {};
+#endif
+
+  /// Check if all the template arguments are the same
+  template <class... T>
+  static constexpr auto are_same_v = are_same<T...>::value;
 
 } // namespace mpt

--- a/test/cpp/test_typed_any.cpp
+++ b/test/cpp/test_typed_any.cpp
@@ -1,0 +1,82 @@
+#include "mpt/typed_any.hpp"
+#include "test_utils.hpp"
+#include <iostream>
+#include <type_traits>
+
+// Test the construction of typed "any" objects
+mpt::test::errors test_simple() {
+
+  mpt::test::errors errors;
+
+  mpt::typed_any<int, float, double> a = 1.f;
+
+  if (a.type_index() != 1)
+    errors.push_back("Wrong determination of the type index");
+
+  a = 1;
+
+  if (a.type_index() != 0)
+    errors.push_back(
+        "Wrong determination of the type index after re-assigning the object");
+
+  return errors;
+}
+
+// Test the evaluation of functions taking typed "any" objects as a input
+mpt::test::errors test_visit() {
+
+  mpt::test::errors errors;
+
+  mpt::typed_any<int, float, double> a = 1.f;
+
+  mpt::visit_typed_any(
+      [&errors](auto v) {
+        if constexpr (!std::is_same_v<decltype(v), float>)
+          errors.push_back("Wrong determination of the type during the visit");
+      },
+      a);
+
+  // set a new value
+  int i = 1;
+
+  a = i;
+
+  mpt::visit_typed_any(
+      [&errors](auto v) {
+        if constexpr (!std::is_same_v<decltype(v), int>)
+          errors.push_back("Wrong determination of the type during the visit "
+                           "after re-assigning the object");
+      },
+      a);
+
+  mpt::visit_typed_any(
+      [&errors, &i](auto v) {
+        if (v != i) {
+          errors.push_back("Failed to change the value type");
+        }
+      },
+      a);
+
+  // if all types are convertible to the same type this must work
+  int j = mpt::visit_typed_any([](auto v) -> int { return v; }, a);
+
+  if (j != i)
+    errors.push_back("Wrong value returned by mpt::visit_typed_any");
+
+  // check the accessor for each qualification of "a"
+  mpt::visit_typed_any([](auto const &) {}, a);
+  mpt::visit_typed_any([](auto const &) {}, std::as_const(a));
+  mpt::visit_typed_any([](auto &&) {}, std::move(a));
+  // "a" becomes invalid after this point
+
+  return errors;
+}
+
+int main() {
+
+  mpt::test::collector typed_any("typed_any");
+  MPT_TEST_UTILS_ADD_TEST(typed_any, test_simple);
+  MPT_TEST_UTILS_ADD_TEST(typed_any, test_visit);
+
+  return mpt::test::to_return_code(typed_any.run());
+}

--- a/test/cpp/test_typed_any.cpp
+++ b/test/cpp/test_typed_any.cpp
@@ -1,6 +1,5 @@
 #include "mpt/typed_any.hpp"
 #include "test_utils.hpp"
-#include <iostream>
 #include <type_traits>
 
 // Test the construction of typed "any" objects

--- a/test/cpp/test_typed_any.cpp
+++ b/test/cpp/test_typed_any.cpp
@@ -9,12 +9,12 @@ mpt::test::errors test_simple() {
 
   mpt::typed_any<int, float, double> a = 1.f;
 
-  if (a.type_index() != 1)
+  if (a.type_index() != 1u)
     errors.push_back("Wrong determination of the type index");
 
   a = 1;
 
-  if (a.type_index() != 0)
+  if (a.type_index() != 0u)
     errors.push_back(
         "Wrong determination of the type index after re-assigning the object");
 


### PR DESCRIPTION
Implement "typed_any", an object that allows to store any from a set of pre-defined types. This object is a mixture of `std::variant` and `std::any`, with an implementation quite close to the former but using an amount of memory equal to the size of the actual object (and not to the maximum size of all the possible types it can store) plus an unsigned integer that keeps track of the contained type.